### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,35 +3,29 @@ name: CI
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  test:
+  python-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.10]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-      - name: Run pytest
-        run: pytest --maxfail=1 --disable-warnings
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+          python-version: '3.x'
+      - run: pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip install -e .
+      - run: pytest --maxfail=1 --disable-warnings
+
+  react-tests:
+    needs: python-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
-          node-version: '20'
-      - name: Install npm dependencies
-        run: |
-          cd web
-          npm install
-      - name: Run npm tests
-        run: |
-          cd web
-          npm test
+          node-version: '16.x'
+      - run: cd web && npm install
+      - run: cd web && npm test -- --watchAll=false


### PR DESCRIPTION
## Summary
- restructure CI so Python tests run first, then React tests
- update Node version and disable watch mode for React tests

## Testing
- `pytest --maxfail=1 --disable-warnings`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6873598c58f883278b3ae3ca33a154d5